### PR TITLE
Criação indevida de ConcreteSymbol #2

### DIFF
--- a/2017-09-08/ll1/src/br/ufpe/cin/if688/test/FollowSetTest.java
+++ b/2017-09-08/ll1/src/br/ufpe/cin/if688/test/FollowSetTest.java
@@ -139,10 +139,10 @@ public class FollowSetTest extends TestCase{
 			expected.put(nt, new HashSet<GeneralSymbol>());
 		}
 		
-		expected.get(K).add(new ConcreteSymbol(d));
+		expected.get(K).add(d);
 		expected.get(S).add(SpecialSymbol.EOF);
-		expected.get(B).add(new ConcreteSymbol(e));
-		expected.get(A).add(new ConcreteSymbol(d));
+		expected.get(B).add(e);
+		expected.get(A).add(d);
 		
 		assertEquals(follow,expected);
 	}


### PR DESCRIPTION
Alterava a referência e impossibilitava a execução dos testes.